### PR TITLE
Fix asset cache triggering auto regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ assets:
   compress:
     css: false | true | default - development: false, production: true
      js: false | true | default - development: false, production: true
-  cache: false | directory | default: .asset-cache
+  cache: false | directory | default: tmp/.asset-cache
   cdn: https://cdn.example.com
   skip_baseurl_with_cdn: false
    skip_prefix_with_cdn: false

--- a/lib/jekyll/assets/env.rb
+++ b/lib/jekyll/assets/env.rb
@@ -46,7 +46,7 @@ module Jekyll
       # -----------------------------------------------------------------------
 
       def in_cache_dir(*paths)
-        cache_dir = asset_config.fetch("cache", ".asset-cache") || nil
+        cache_dir = asset_config.fetch("cache", "tmp/.asset-cache") || nil
         jekyll.in_source_dir(cache_dir, *paths)
       end
 

--- a/lib/jekyll/assets/hooks/cache.rb
+++ b/lib/jekyll/assets/hooks/cache.rb
@@ -1,5 +1,5 @@
 Jekyll::Assets::Hook.register :env, :init do
-  if (cache_dir = asset_config.fetch("cache", ".asset-cache"))
+  if (cache_dir = asset_config.fetch("cache", "tmp/.asset-cache"))
     self.cache = Sprockets::Cache::FileStore.new(jekyll.in_source_dir(cache_dir))
   end
 end

--- a/spec/support/jekyll.rb
+++ b/spec/support/jekyll.rb
@@ -122,7 +122,7 @@ module Jekyll
     # -------------------------------------------------------------------------
 
     def self.cleanup_trash
-      %W(.asset-cache .jekyll-metadata _site).each do |v|
+      %W(tmp/.asset-cache .jekyll-metadata _site).each do |v|
         FileUtils.rm_rf(File.join(File.expand_path("../../fixture", __FILE__), v))
       end
     end


### PR DESCRIPTION
The default asset cache directory (`.asset-cache`) is within the watch paths for auto regeneration by jekyll. This can triggers multiple regenerations when modifying assets, and significantly slows the generation time as more and more assets are cached.

The `tmp` directory is automatically excluded by the regeneration watcher, so by setting the asset cache path to `tmp/.asset-cache` we can eliminate this issue.
