### PR TITLE
Make sprockets index files accept .js.liquid and .css.liquid file extensions

### DIFF
--- a/lib/jekyll/assets/processors/liquid.rb
+++ b/lib/jekyll/assets/processors/liquid.rb
@@ -5,6 +5,7 @@ module Jekyll
         FOR = %W(
           text/css text/sass text/less application/javascript
           text/scss text/coffeescript text/javascript).freeze
+        EXT = %W(.liquid .js.liquid .css.liquid).freeze
 
         # --------------------------------------------------------------------
 
@@ -28,7 +29,12 @@ end
 # There might be a few missing, if there is please do let me know.
 # ----------------------------------------------------------------------------
 
-Sprockets.register_engine ".liquid", Jekyll::Assets::Processors::Liquid
+Jekyll::Assets::Processors::Liquid::EXT.each do |ext|
+  Sprockets.register_engine(
+    ext, Jekyll::Assets::Processors::Liquid
+  )
+end
+
 Jekyll::Assets::Processors::Liquid::FOR.each do |val|
   Sprockets.register_preprocessor(
     val, Jekyll::Assets::Processors::Liquid

--- a/lib/jekyll/assets/processors/liquid.rb
+++ b/lib/jekyll/assets/processors/liquid.rb
@@ -5,7 +5,7 @@ module Jekyll
         FOR = %W(
           text/css text/sass text/less application/javascript
           text/scss text/coffeescript text/javascript).freeze
-        EXT = %W(.liquid .js.liquid .css.liquid).freeze
+        EXT = %W(.liquid .js.liquid .css.liquid .scss.liquid).freeze
 
         # --------------------------------------------------------------------
 

--- a/spec/fixture/_assets/css/index.css
+++ b/spec/fixture/_assets/css/index.css
@@ -1,0 +1,3 @@
+/*
+ *= require liquid
+ */

--- a/spec/lib/jekyll/assets/addons/processors/liquid_spec.rb
+++ b/spec/lib/jekyll/assets/addons/processors/liquid_spec.rb
@@ -42,4 +42,19 @@ describe Jekyll::Assets::Processors::Liquid do
        end
     end
   end
+
+  context "when sprockets requires a liquid file" do
+    let(:asset) { env.find_asset("index") }
+    let(:env) { Jekyll::Assets::Env.new(stub_jekyll_site) }
+    let(:source) { asset.to_s }
+
+    it "lets the user use Liquid" do
+      expect(source).not_to match(/\{{2}\s*site\.background_image\s*\}{2}/)
+      expect(source).to match(/background:\s*url\("\/assets\/ruby\.png"\)/)
+    end
+
+    it "provides the right extension" do
+      expect(asset.logical_path).to eq "index.css"
+    end
+  end
 end


### PR DESCRIPTION
When requiring a ```.css.liquid``` or ```.js.liquid``` file in a sprockets, I was getting the error ```couldn't find file 'filename' with type 'application/javascript'```. This solves this problem.