### PR TITLE
Sprockets resolve cache

### DIFF
--- a/lib/jekyll/assets/cached.rb
+++ b/lib/jekyll/assets/cached.rb
@@ -15,7 +15,12 @@ module Jekyll
       def initialize(env)
         @parent = env
         @jekyll = env.jekyll
+        @resolve_cache = {}
         super env
+      end
+
+      def resolve(*args)
+        @resolve_cache[args] ||= super
       end
     end
   end

--- a/spec/tests/lib/jekyll/assets/cached_spec.rb
+++ b/spec/tests/lib/jekyll/assets/cached_spec.rb
@@ -35,4 +35,16 @@ describe Jekyll::Assets::Cached do
       Jekyll::Assets::Env
     )
   end
+
+  #
+
+  it "caches resolved paths" do
+    first = cached.resolve("ruby.png")
+    second = cached.resolve("ruby.png")
+
+    expect(first).to match /assets\/img\/ruby\.png/
+    expect(first).to eq second
+
+    expect(first.object_id).to eq second.object_id
+  end
 end


### PR DESCRIPTION
I think this is the real fix to https://github.com/jekyll/jekyll-assets/issues/228 (I don't think https://github.com/jekyll/jekyll-assets/commit/db4cd7f8e04aa985fdcef97b9f3203b16164cb17 fully addressed the problem).

This PR brings down the build time of our Jekyll site from about 80 seconds to about 40 seconds on my machine. The big one is the `resolve` method. If your site contains the same asset in multiple pages, putting a debugger in there will show you that that method it is being called repeatedly with the same arguments, trying to resolve the same stuff over and over again.

Fixing it by caching the result and by overwriting the Sprockets superclass method.

This is probably not the best way to fix this, but it works and we verified that the generated output of our site is identical.

Is there a better way to do this?

Is there something we need to do for incremental regeneration?

Thoughts?

@envygeeks @rafaelfranca @knverey / cc @parkr @admhlt 