### PR TITLE
Add missing leading space to key-only attributes

### DIFF
--- a/lib/jekyll/assets/liquid/tag/parser.rb
+++ b/lib/jekyll/assets/liquid/tag/parser.rb
@@ -92,7 +92,7 @@ module Jekyll
 
           def to_html
             (self[:html] || {}).map do |key, val|
-              val == true || val == "true" ? key.to_s : %( #{key}="#{val}")
+              val == true || val == "true" ? " #{key}" : %( #{key}="#{val}")
             end.join
           end
 

--- a/spec/tests/lib/jekyll/assets/liquid/tag/parser_spec.rb
+++ b/spec/tests/lib/jekyll/assets/liquid/tag/parser_spec.rb
@@ -147,6 +147,23 @@ describe Jekyll::Assets::Liquid::Tag::Parser do
 
   #
 
+  it "separates attributes with leading spaces" do
+    expect(subject.new("app.js defer", "js").to_html).to eq(
+      " defer"
+    )
+    expect(subject.new("app.js id:1", "js").to_html).to eq(
+      %( id="1")
+    )
+    expect(subject.new("app.js defer id:1", "js").to_html).to eq(
+      %( defer id="1")
+    )
+    expect(subject.new("app.js id:1 defer", "js").to_html).to eq(
+      %( id="1" defer)
+    )
+  end
+
+  #
+
   it "does not allocate boolean arguments as proxy values", :proxies => true do
     input = "img.jpg magick:2x:raise"
     expect_it = expect { subject.new(input, "img") }


### PR DESCRIPTION
HTML linter got upset. For example, using

```
{% javascript app.js async %}
```

Before:

```
<script type="text/javascript" src="/assets/app.js"async></script>
```

After:

```
<script type="text/javascript" src="/assets/app.js" async></script>
```

This is consistent with how the other attributes are rendered.