### PR TITLE
[#289] Mini Magick note

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ end
 
 ### Image Magick Proxy arguments:
 
+**NOTE: You'll need the `mini_magick` gem installed for these to work**
+To install `mini_magick`, add `gem "mini_magick"` to your `Gemfile`
+
 * `magick:resize:<value>`
 * `magick:format:<value>`
 * `magick:quality:<value>`


### PR DESCRIPTION
I've added a note to install `mini_magick` before you try to use the various `magick:` stuff. It was unclear to me why they won't work out of the box. Maybe this will help someone in the same situation.

Fixes #289