### PR TITLE
Update disabled caching message

### DIFF
--- a/lib/jekyll/assets/hooks/cache.rb
+++ b/lib/jekyll/assets/hooks/cache.rb
@@ -23,7 +23,7 @@ Jekyll::Assets::Hook.register :env, :init do
     end
 
   else
-    Jekyll.logger.info "", "Caching disabled however, " \
-      "if you use proxies it could still possibly be created."
+    Jekyll.logger.info "", "Caching is disabled by configuration. " \
+      "However, if you're using proxies, a cache might still be created."
   end
 end


### PR DESCRIPTION
I've been testing disabled caching and the message that pops up in Jekyll's log could be worded a little more clearly. Here's my attempt.