### PR TITLE
Adding details on `.es6` extension to Sprockets instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ folder as the sole source (base folder.)***
 ## Addons
 
 * CSS Auto Prefixer - add "autoprefixer-rails" to your Gemfile.
-* ES6 Transpiler (through Babel) - add "sprockets-es6" to your Gemfile.
+* ES6 Transpiler (through Babel) - add "sprockets-es6" to your Gemfile — any `.es6` files (e.g. `main.js.es6`) will be transpiled
 * Bootstrap - add "bootstrap-sass" to your Gemfile, and `@import 'boostrap-sprockets'; @import 'bootstrap'`
 * Font Awesome - add "font-awesome-sass" to your Gemfile, and `@import 'font-awesome-sprockets'; @import 'font-awesome'`
 * Image Magick - add "mini_magick" to your Gemfile, only works with `img`, `image`.


### PR DESCRIPTION
I might be being silly or have missed something, but it took me a while to figure out that you need to add an `.es6` extension to any files you want to be transpiled (e.g. `your-file-name.js.es6`) after installing the `sprockets-es6` gem.

Would be lovely to include this as an explicit instruction in the readme to help people get that ES2016 goodness even more easily 🔥🔥🔥 

Thanks! 😍 