### PR TITLE
Depend on concurrent-ruby since we use it directly

### DIFF
--- a/Gem.gemspec
+++ b/Gem.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("jekyll", ">= 3.0", "~> 3.1")
   spec.add_runtime_dependency("pathutil", ">= 0.8")
   spec.add_runtime_dependency("extras", "~> 0.1")
+  spec.add_runtime_dependency("concurrent-ruby", "~> 1.0")
 
   spec.add_development_dependency("nokogiri", "~> 1.6")
   spec.add_development_dependency("luna-rspec-formatters", "~> 3.5")

--- a/lib/jekyll/assets/manifest.rb
+++ b/lib/jekyll/assets/manifest.rb
@@ -2,6 +2,8 @@
 # Copyright: 2012 - 2016 - MIT License
 # Encoding: utf-8
 
+require 'concurrent/future'
+
 module Jekyll
   module Assets
     class Manifest < Sprockets::Manifest


### PR DESCRIPTION
Sprockets may bring it in, but relying on a transitive dependency
presumes that we're locked on a Sprockets version that happens to have
required concurrent-ruby by the time we use it.
