### PR TITLE
Fix missing `image` filter

### DIFF
--- a/lib/jekyll/assets/liquid/filters.rb
+++ b/lib/jekyll/assets/liquid/filters.rb
@@ -9,7 +9,7 @@ module Jekyll
     module Liquid
       module Filters
         ACCEPTABLE_FILTERS = [:css, :img, :asset_path, :stylesheet,
-          :javascript, :style, :img, :js]
+          :javascript, :style, :image, :js]
 
         # --
         # The base filters.

--- a/spec/tests/lib/jekyll/assets/liquid/filters_spec.rb
+++ b/spec/tests/lib/jekyll/assets/liquid/filters_spec.rb
@@ -6,21 +6,62 @@
 
 require "rspec/helper"
 describe Jekyll::Assets::Liquid::Filters do
-  before :each do
-    site.process
-  end
-
-  #
-
   let :site do
     stub_jekyll_site
   end
 
+  let :renderer do
+    Renderer.new site
+  end
+
   #
 
-  it "uses tags and returns the HTML" do
-    expect(fragment(site.pages.first.to_s).xpath("p//img[contains(@alt, 'filter')]").size).to(
-      eq 1
-    )
+  [
+    %w(img ruby.png), %w(image ruby.png),
+    %w(js bundle),    %w(javascript bundle),
+    %w(css bundle),   %w(stylesheet bundle),
+    %w(style bundle), %w(asset_path bundle.css)
+  ].each do |name, *args|
+    context "#{name} filter" do
+      subject do
+        renderer.filter(name, *args)
+      end
+
+      it "matches the #{name} tag" do
+        is_expected.to eq renderer.tag(name, *args)
+      end
+    end
+  end
+
+  class Renderer
+    include Jekyll::Assets::Liquid::Filters
+
+    def initialize(site)
+      @site = site
+      @sprockets = Jekyll::Assets::Env.new(@site)
+      @context = Liquid::Context.new({}, {}, { :site => @site, :sprockets => @sprockets })
+    end
+
+    def filter(name, *args)
+      public_send name, *args
+    end
+
+    def tag(name, *args)
+      Jekyll::Assets::Liquid::Tag.send(:new, name, *args, []).render(@context)
+    end
+  end
+
+  context "fixture site" do
+    before :each do
+      site.process
+    end
+
+    #
+
+    it "uses tags and returns the HTML" do
+      expect(fragment(site.pages.first.to_s).xpath("p//img[contains(@alt, 'filter')]").size).to(
+        eq 1
+      )
+    end
   end
 end


### PR DESCRIPTION
And add specs demonstrating that all filters render their corresponding tag.