### PR TITLE
Allow cache dirs outside the main source dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.analysis
+/.asset-cache
 /spec/fixture/.*
 /spec/fixture/_site
 /stackprof.dump

--- a/lib/jekyll/assets/env.rb
+++ b/lib/jekyll/assets/env.rb
@@ -111,6 +111,12 @@ module Jekyll
         path ? super(path) : super()
         @jekyll = jekyll
 
+        # Analagous to Jekyll::Site @source and @destination paths
+        @cache_path = asset_config.fetch("cache", ".asset-cache")
+        if File.exist?(cache_path_in_source_dir = jekyll.in_source_dir(@cache_path))
+          @cache_path = cache_path_in_source_dir
+        end
+
         # XXX: In 3.0, we need to drop anything to do with instance eval,
         #   and imply pass the instance, this will make our code cleaner.
 
@@ -142,9 +148,9 @@ module Jekyll
       # @return [Pathname/Pathutil]
       # --
       def in_cache_dir(*paths)
-        jekyll.in_source_dir(asset_config["cache"] || ".asset-cache",
-          *paths
-        )
+        paths.reduce(@cache_path) do |base, path|
+          Jekyll.sanitized_path(base, path)
+        end
       end
 
       # --

--- a/lib/jekyll/assets/liquid/tag/proxied_asset.rb
+++ b/lib/jekyll/assets/liquid/tag/proxied_asset.rb
@@ -155,7 +155,7 @@ module Jekyll
           def cache_file
             return true if @_cached || find_cached
 
-            filename.dirname.mkdir_p unless filename.dirname == env.in_cache_dir
+            filename.dirname.mkdir_p
             Pathutil.new(asset.filename).cp filename
             true
           end

--- a/spec/support/cache.rb
+++ b/spec/support/cache.rb
@@ -4,7 +4,7 @@
 
 RSpec.configure do |config|
   config.before :all do
-    Pathutil.new("../../fixture/.asset-cache").expand_path(__FILE__)
+    Pathutil.new("../../.asset-cache").expand_path(__FILE__)
       .rm_rf
   end
 end


### PR DESCRIPTION
Better for e.g. Guard and Watchman since they needn't get gummed up watching large deep cache dirs.

TODO: Setting the cache dir is untested currently, so we'll need to add coverage before demonstrating that the feature behaves as expected.