### PR TITLE
Readme scss import example syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ Use the `@import` statement. Given a list of files in `_assets/css`:
 ...have this in your `main.scss`:
 
 ```scss
-@import 'responsive'
-@import 'fonts'
+@import 'responsive';
+@import 'fonts';
 // ...
 ```
 


### PR DESCRIPTION
- Readme: Added semicolons after import statements for scss files. Not
a big deal, but I got a missing ; error implementing this in my project
after shamelessly copy-pasting the code from readme.