### PR TITLE
Fix auto image size reading

### DIFF
--- a/lib/jekyll/assets/liquid/drop.rb
+++ b/lib/jekyll/assets/liquid/drop.rb
@@ -57,7 +57,7 @@ module Jekyll
 
         def dimensions
           if image?
-            @dimensions ||= FastImage.new(asset.filename).size
+            @dimensions ||= FastImage.size(asset.filename.to_s)
           end
         end
 

--- a/lib/jekyll/assets/liquid/tag/defaults/image.rb
+++ b/lib/jekyll/assets/liquid/tag/defaults/image.rb
@@ -55,7 +55,7 @@ module Jekyll
               resize_image = @env.asset_config["features"]["automatic_img_size"]
 
               if !@env || resize_image
-                dimensions = FastImage.new(@asset.filename).size
+                dimensions = FastImage.size(@asset.filename.to_s)
                 return unless dimensions
                 @args[:html] ||= {}
 


### PR DESCRIPTION
FastImage assumes that if image argument responds to `read` that it will act like `IO#read` and subsequent calls will advance through the stream. [`Pathutil#read`](https://github.com/envygeeks/pathutil/blob/master/lib/pathutil.rb#L496-L509) uses `File::read` which reopens the file each time causing infinite loops. If we just pass in a simple string, FastImage will use `File::open` and avoid the issue.

Fixes #381