### PR TITLE
Sprockets cache may live outside the source dir

### DIFF
--- a/lib/jekyll/assets/env.rb
+++ b/lib/jekyll/assets/env.rb
@@ -6,6 +6,7 @@ module Jekyll
   module Assets
     class Env < Sprockets::Environment
       attr_accessor :jekyll
+      attr_reader :cache_path
 
       class << self
 
@@ -148,7 +149,7 @@ module Jekyll
       # @return [Pathname/Pathutil]
       # --
       def in_cache_dir(*paths)
-        paths.reduce(@cache_path) do |base, path|
+        paths.reduce(cache_path) do |base, path|
           Jekyll.sanitized_path(base, path)
         end
       end

--- a/lib/jekyll/assets/hooks/cache.rb
+++ b/lib/jekyll/assets/hooks/cache.rb
@@ -9,18 +9,10 @@ Jekyll::Assets::Hook.register :env, :init do
   )
 
   if cache != false && type != "memory"
-    self.cache = begin
-      Sprockets::Cache::FileStore.new(
-        jekyll.in_source_dir(
-          cache
-        )
-      )
-    end
+    self.cache = Sprockets::Cache::FileStore.new(cache_path)
 
   elsif cache && type == "memory"
-    self.cache = begin
-      Sprockets::Cache::MemoryStore.new
-    end
+    self.cache = Sprockets::Cache::MemoryStore.new
 
   else
     Jekyll.logger.info "", "Asset caching is disabled by configuration. " \


### PR DESCRIPTION
Followup to #347 which allowed the cache dir to live outside the source dir.

The env init hook still forced the Sprockets cache to live in the cache dir within the source dir, though.

Just use the actual cache dir (which is already properly namespaced) instead.