### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ An example of using Liquid in your SCSS:
 
 ```scss
 .bg {
-  background: url(asset_path("{{ site.background_image }}"));
+  background: url(asset_path(asset_logical_name));
 }
 ```
 


### PR DESCRIPTION
The inclusion of liquid tags in SCSS didn't work for me as of the most recent version of jekyll-assets and jekyll 3.1.6, but the changed syntax does. I found mention of the SCSS-specific variables on another site.  Oversight in the readme from prior versions perhaps?

in reference to [#402](https://github.com/jekyll/jekyll-assets/issues/402)