### PR TITLE
Plugins is deprecated. Use plugins_dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 
 ```yaml
 # _config.yml
-plugins:
+plugins_dir:
   - jekyll-assets
 ```
 


### PR DESCRIPTION
Jekyll v3.4.3
Ubuntu 16.04

The following instructions in the current readme file

plugins:
  - jekyll-assets

Gives the following error when running jekyll build

Deprecation: The 'plugins' configuration option has been renamed to 'plugins_dir'. Please update your config file accordingly.

plugins:
  - jekyll-assets

Should be changed to

plugins_dir:
  - jekyll-assets