### PR TITLE
Use Array#concat instead of Array#push to add asset source files to excludes

### DIFF
--- a/lib/jekyll/assets/env.rb
+++ b/lib/jekyll/assets/env.rb
@@ -258,7 +258,7 @@ module Jekyll
       private
       def excludes!
         excludes = Config.defaults[:sources]
-        @jekyll.config["exclude"].push(excludes)
+        @jekyll.config["exclude"].concat(excludes)
         @jekyll.config["exclude"].uniq!
       end
 


### PR DESCRIPTION
This fixes `Jekyll::Assets::Env#excludes!` to no longer push its asset sources as an array _in_ the exclude array of Jekyll by using `Array#concat` instead of `Array#push`.

Otherwise the following error occures:
```
 /gems/jekyll-3.6.0/lib/jekyll.rb:168:in `sanitized_path': undefined method `start_with?' for #<Array:0x00563da8b44e98> (NoMethodError)
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:70:in `block in custom_excludes'
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:70:in `map'
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:70:in `custom_excludes'
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:83:in `to_exclude'
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:94:in `listen_ignore_paths'
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:45:in `build_listener'
   from /gems/jekyll-watch-1.5.0/lib/jekyll/watcher.rb:23:in `watch'
   from /gems/jekyll-3.6.0/lib/jekyll/commands/build.rb:94:in `call'
   from /gems/jekyll-3.6.0/lib/jekyll/commands/build.rb:94:in `watch'
   from /gems/jekyll-3.6.0/lib/jekyll/commands/build.rb:43:in `process'
   from /gems/jekyll-3.6.0/lib/jekyll/commands/serve.rb:42:in `block (3 levels) in init_with_program'
   from /gems/jekyll-3.6.0/lib/jekyll/commands/serve.rb:42:in `each'
   from /gems/jekyll-3.6.0/lib/jekyll/commands/serve.rb:42:in `block (2 levels) in init_with_program'
   from /gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
   from /gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
   from /gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
   from /gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
   from /gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
   from /gems/jekyll-3.6.0/exe/jekyll:15:in `<top (required)>'
   from /bin/jekyll:23:in `load'
   from /bin/jekyll:23:in `<main>'
```